### PR TITLE
Move preferences to local storage

### DIFF
--- a/src/_locales/de-DE/messages.json
+++ b/src/_locales/de-DE/messages.json
@@ -87,7 +87,7 @@
         "message": "Erstellen"
     },
     "subjects_prefix_switch.label.options.contextmenu": {
-        "message": "&quot;SubSwitch&quot; im Kontextmenü anzeigen"
+        "message": "\"SubSwitch\" im Kontextmenü anzeigen"
     },
     "subjects_prefix_switch.label.options.createdBy": {
         "message": "Entwickelt von"
@@ -123,7 +123,7 @@
         "message": "Grundeinstellungen"
     },
     "subjects_prefix_switch.label.options.msgSubject": {
-        "message": "Vor Betreffzeile &quot;SubSwitch&quot; anzeigen"
+        "message": "Vor Betreffzeile \"SubSwitch\" anzeigen"
     },
     "subjects_prefix_switch.label.options.offbydefault": {
         "message": "Entiketten standardmäßig deaktivieren"

--- a/src/_locales/sv-SE/messages.json
+++ b/src/_locales/sv-SE/messages.json
@@ -90,7 +90,7 @@
         "message": "Nytt"
     },
     "subjects_prefix_switch.label.options.contextmenu": {
-        "message": "Visa &quot;SubSwitch&quot; i snabbmenyn"
+        "message": "Visa \"SubSwitch\" i snabbmenyn"
     },
     "subjects_prefix_switch.label.options.createdBy": {
         "message": "Skapat av"
@@ -108,7 +108,7 @@
         "message": "Ta bort"
     },
     "subjects_prefix_switch.label.options.discovery.autodisable.description.wildcard1": {
-        "message": "Frågetecken ( ? ) kan användas som ett jokertecken. (Exempel: &quot;?@mozilla.com&quot;, &quot;test@?.com&quot; eller &quot;t?t@m?a.c?&quot; kommer att matchas när &quot;test@mozilla.com&quot; är avsändare)"
+        "message": "Frågetecken ( ? ) kan användas som ett jokertecken. (Exempel: \"?@mozilla.com\", \"test@?.com\" eller \"t?t@m?a.c?\" kommer att matchas när \"test@mozilla.com\" är avsändare)"
     },
     "subjects_prefix_switch.label.options.discoveryIgnoreSigns": {
         "message": "Tecken som skall ignoreras när prefix jämförs"
@@ -126,7 +126,7 @@
         "message": "Allmänt"
     },
     "subjects_prefix_switch.label.options.msgSubject": {
-        "message": "Visa &quot;SubSwitch&quot; före ämnesfältet"
+        "message": "Visa \"SubSwitch\" före ämnesfältet"
     },
     "subjects_prefix_switch.label.options.offbydefault": {
         "message": "Dölj prefix som standard"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,14 +2,14 @@
   "manifest_version": 2,
   "name": "SubSwitch",
   "description": "__MSG_extensionDescription__",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Tomasz Krajewski",
   "homepage_url": "https://github.com/tomaszkrajewski/tb-SubSwitch",
   "browser_specific_settings": {
     "gecko": {
       "id": "{957509b1-217a-46c7-b08b-f67d08d53883}",
       "strict_min_version": "115.0",
-      "strict_max_version": "134.*"
+      "strict_max_version": "139.*"
     }
   },
   "icons": {

--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -1,0 +1,39 @@
+const DEFAULTS = {
+    "addRDtoEmail": true,
+    "beforeMsgSubject": true,
+    "contextmenu": true,
+    "defaultrd": "1",
+    "discoveryIgnoreList": "bugzilla?@?.com",
+    "discoveryIgnoreSigns": "[]/ ",
+    "discoveryItemPattern": "\\[.+\\]",
+    "entries_split_sign": "##",
+    "entry_split_sign": "~~",
+    "loadRDfromEmail": true,
+    "offbydefault": false,
+    "rds": "Organizational mail~~[ORG]~~false##Project ABCD~~[ABCD/{number:NN}][{date:yyyy/mm/dd}]~~true##Private mail~~[PRV]~~true~~[PRIV]",
+    "rds_addresses": "",
+    "rds_sequences": "",
+}
+
+export async function getPref(name) {
+    if (!DEFAULTS.hasOwnProperty(name)) {
+        throw new Error (`Unknown preference: ${name}`)
+    }
+    return browser.storage.local
+        .get({[`preference.${name}`]: DEFAULTS[name]})
+        .then(rv => rv[`preference.${name}`])
+}
+
+export async function setPref(name, value) {
+    return browser.storage.local.set({[`preference.${name}`]: value});
+}
+
+export async function migrateToLocalStorage() {
+    for (let name of Object.keys(DEFAULTS)) {
+        let value = await browser.LegacyPrefs.getUserPref(`extensions.subjects_prefix_switch.${name}`);
+        if (value !== null) {
+            await setPref(name, value);
+            await browser.LegacyPrefs.clearUserPref(`extensions.subjects_prefix_switch.${name}`)
+        }
+    }
+}

--- a/src/modules/subswitch_items.js
+++ b/src/modules/subswitch_items.js
@@ -1,4 +1,5 @@
 import * as utils from "./subswitch_utils.mjs";
+import * as preferences from "./preferences.js"
 
 class SubswitchPrefixItem {
     constructor(aLabel, aPrefix) {
@@ -185,23 +186,23 @@ class SubswitchPrefixItem {
 async function loadPrefixes() {
     utils.dumpStr('-> loadPrefixes START');
 
-    let entriesSplitSign = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.entries_split_sign`);
+    let entriesSplitSign = await preferences.getPref(`entries_split_sign`);
     // com.ktsystems.subswitch.Const.ENTRIES_SPLIT_SIGN
     ENTRIES_SPLIT_SIGN = entriesSplitSign;
 
-    let entrySplitSign = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.entry_split_sign`);
+    let entrySplitSign = await preferences.getPref(`entry_split_sign`);
     // com.ktsystems.subswitch.Const.ENTRY_SPLIT_SIGN
     ENTRY_SPLIT_SIGN = entrySplitSign;
 
-    let ignoreSigns = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.discoveryIgnoreSigns`);
+    let ignoreSigns = await preferences.getPref(`discoveryIgnoreSigns`);
     IGNORE_SIGNS = ignoreSigns;
 
-    let prefixesDataString = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.rds`);
-    let prefixesAddressesString = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.rds_addresses`);
-    let prefixesSequencesString = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.rds_sequences`);
+    let prefixesDataString = await preferences.getPref(`rds`);
+    let prefixesAddressesString = await preferences.getPref(`rds_addresses`);
+    let prefixesSequencesString = await preferences.getPref(`rds_sequences`);
 
-    let offbydefault = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.offbydefault`);
-    let defaultRD = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.defaultrd`);
+    let offbydefault = await preferences.getPref(`offbydefault`);
+    let defaultRD = await preferences.getPref(`defaultrd`);
 
     utils.dumpStr('-> initPrefixesArray prefixesDataString ' + prefixesDataString);
     utils.dumpStr('-> initPrefixesArray prefixesAddressesString ' + prefixesAddressesString);
@@ -352,12 +353,12 @@ export function savePrefixes() {
 
     PREFIXES_LIST.forEach(writer.writeItem, writer);
 
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.rds`, writer.toString());
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.rds_addresses`, writer.toAddressesString());
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.rds_sequences`, writer.toSeqString());
+    preferences.setPref(`rds`, writer.toString());
+    preferences.setPref(`rds_addresses`, writer.toAddressesString());
+    preferences.setPref(`rds_sequences`, writer.toSeqString());
 
     if (PREFIXES_LIST.defaultPrefixIndex != undefined) {
-        browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.defaultrd`, PREFIXES_LIST.defaultPrefixIndex);
+        preferences.setPref(`defaultrd`, PREFIXES_LIST.defaultPrefixIndex);
     }
 
     utils.dumpStr('-> savePrefixes END');
@@ -379,7 +380,7 @@ export function savePrefixesSequences() {
 
     PREFIXES_LIST.forEach(writer.writeItem, writer);
 
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.rds_sequences`, writer.toSeqString());
+    preferences.setPref(`rds_sequences`, writer.toSeqString());
 
     utils.dumpStr('<- savePrefixesSequences; ');
 };

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,7 @@
 import * as i18n from "../modules/i18n.mjs"
 import * as utils from "../modules/subswitch_utils.mjs"
 import * as items from "../modules/subswitch_items.js"
+import * as preferences from "../modules/preferences.js"
 
 i18n.localizeDocument();
 
@@ -40,7 +41,7 @@ toElements.forEach(toElement => {
 // load preferences
 let prefElements = document.querySelectorAll('[data-preference]');
 for (let prefElement of prefElements) {
-    let value = await browser.LegacyPrefs.getPref(`extensions.subjects_prefix_switch.${prefElement.dataset.preference}`);
+    let value = await preferences.getPref(`${prefElement.dataset.preference}`);
     utils.dumpStr(prefElement.tagName);
 
     // handle checkboxes
@@ -52,7 +53,7 @@ for (let prefElement of prefElements) {
         }
         // enable auto save
         prefElement.addEventListener("change", () => {
-            browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.${prefElement.dataset.preference}`, prefElement.checked);
+            preferences.setPref(`${prefElement.dataset.preference}`, prefElement.checked);
         })
     // handle checkboxes
     } else if (prefElement.tagName == "INPUT" && prefElement.type == "text") {
@@ -63,7 +64,7 @@ for (let prefElement of prefElements) {
         }
         // enable auto save
         prefElement.addEventListener("change", () => {
-            browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.${prefElement.dataset.preference}`, prefElement.value);
+            preferences.setPref(`${prefElement.dataset.preference}`, prefElement.value);
         })
     // handle richlistbox / select
     } else if (prefElement.tagName == "SELECT") {
@@ -76,7 +77,7 @@ for (let prefElement of prefElements) {
         //FIXME: SAVING this way is not working, so saving directly in addAutoSwitch and removeAutoswitch
         prefElement.addEventListener("change", () => {
             utils.dumpStr("change "+prefElement);
-            browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.${prefElement.dataset.preference}`, getStringFromListbox(prefElement));
+            preferences.setPref(`${prefElement.dataset.preference}`, getStringFromListbox(prefElement));
         })
     }
 }
@@ -258,7 +259,7 @@ function addAutoSwitch() {
     input.innerText = "";
     input.value = "";
 
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.discoveryIgnoreList`, getStringFromListbox(listbox));
+    preferences.setPref(`discoveryIgnoreList`, getStringFromListbox(listbox));
 };
 
 function removeAutoswitch() {
@@ -268,14 +269,14 @@ function removeAutoswitch() {
     if (selected >= 0) {
         listbox.remove(selected);
 
-        browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.discoveryIgnoreList`, getStringFromListbox(listbox));
+        preferences.setPref(`discoveryIgnoreList`, getStringFromListbox(listbox));
     }
 };
 
 function saveDefaultPrefix(prefixDefault) {
     utils.dumpStr("saveDefaultPrefix START prefixDefault" + prefixDefault);
 
-    browser.LegacyPrefs.setPref(`extensions.subjects_prefix_switch.defaultrd`, prefixDefault);
+    preferences.setPref(`defaultrd`, prefixDefault);
 
     utils.dumpStr("saveDefaultPrefix END");
 };


### PR DESCRIPTION
With the introduction of Thunderbird's new Release Channel, Experiment add-ons have to be updated every 4 weeks. We should get this add-on to be a pure WebExtension, so you no longer have to update the add-on.

This PR migrates the preferences from the legacy pref branch to the local storage. The Experiment is now only used for the migration and can be removed with your next update for Thunderbird 140.

This PR also fixes an issue in the locale files, where the html entity `&quot;` was still used.